### PR TITLE
Fix filename to avoid multi periods.

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function ( options ) {
             say( 'File is a buffer. Need to write buffer to temp file...' );
 
             var tmpGulpfileName = util.format(
-                '%s.tmp.%s%s',
+                '%s-tmp-%s%s',
                 path.basename( gulpfile.name, gulpfile.ext ),
                 new Date().getTime(),
                 gulpfile.ext

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gulp-util": "3.0.1",
     "lodash": "2.4.1",
     "resolve": "1.0.0",
     "through2": "1.1.1"
@@ -34,7 +33,7 @@
     "gulp-istanbul": "^0.6.0",
     "gulp-mocha": "^2.0.0",
     "gulp-replace": "~0.3.0",
-    "gulp-util": "~2.2.16",
+    "gulp-util": "~3.0.1",
     "mocha": "~1.20.1",
     "proxyquire": "~1.0.1",
     "should": "~4.0.1",


### PR DESCRIPTION
The file name as `gulpfile.tmp.321321321.js` is having issues with `js-rechoir`. They are identifying the extension as `.tmp.321321321.js` and this is not a valid extension for any loader. I tried reporting an issue with the folks there, but I don't think they will change their side. It is just easier for `gulp-chug` to change the filename format.